### PR TITLE
Adding possibility to pass expiry time to constructor.

### DIFF
--- a/src/main/java/no/spid/api/client/SpidApiClient.java
+++ b/src/main/java/no/spid/api/client/SpidApiClient.java
@@ -364,9 +364,8 @@ public class SpidApiClient {
      *
      * @param token the token to refresh
      * @return true if the token could be refreshed, false if not.
-     * @throws SpidOAuthException If an OAuth related error occurs
      */
-    private boolean refreshToken(SpidOAuthToken token) throws SpidOAuthException {
+    private boolean refreshToken(SpidOAuthToken token) {
         OAuthJSONAccessTokenResponse oAuthResponse;
 
         try {
@@ -383,9 +382,9 @@ public class SpidApiClient {
             oAuthResponse = oAuthClient.accessToken(request);
 
         } catch (OAuthSystemException e) {
-            throw new SpidOAuthException(e);
+            return false;
         } catch (OAuthProblemException e) {
-            throw new SpidOAuthException(e);
+            return false;
         }
 
         SpidOAuthToken newToken = new SpidOAuthToken(oAuthResponse.getOAuthToken(), token.getType());

--- a/src/main/java/no/spid/api/oauth/SpidOAuthToken.java
+++ b/src/main/java/no/spid/api/oauth/SpidOAuthToken.java
@@ -14,11 +14,15 @@ public class SpidOAuthToken {
     private SpidOAuthTokenType type;
 
     public SpidOAuthToken(OAuthToken basicToken, SpidOAuthTokenType type) {
+        this(basicToken, type, System.currentTimeMillis() + basicToken.getExpiresIn() * 1000);
+    }
+
+    public SpidOAuthToken(OAuthToken basicToken, SpidOAuthTokenType type, long expiresAt) {
         accessToken = basicToken.getAccessToken();
         refreshToken = basicToken.getRefreshToken();
         scope = basicToken.getScope();
         expiresIn = basicToken.getExpiresIn();
-        expiresAt = System.currentTimeMillis() + expiresIn * 1000;
+        this.expiresAt = expiresAt;
         this.type = type;
     }
 


### PR DESCRIPTION
# Why
When we deserialize our session objects (basically an own `Serializable` representation of the `SpidOauthToken`) we create new instances of `SpidOauthToken`. Since the `expiresAt` is only possible to define in relation to the instance creation timestamp, we have to make ugly hacks like passing in negative values for `expiresIn`, or else our tokens are never refreshed.

# Pseudo usage code 
## Before
```Java
OauthCredentials deserializedCredentials = sessionStore.get(sessionId);
long fakeExpiresIn = (System.currentTimeMillis() - deserializedCredentials.expiresAt()) / 1000;
SpidOauthToken token = new SpidOauthToken(new BasicOauthToken(deserializedCredentials.getAccessToken(), fakeExpiresIn), USER)
```
## After
```Java
OauthCredentials deserializedCredentials = sessionStore.get(sessionId);
SpidOauthToken token = new SpidOauthToken(new BasicOauthToken(deserializedCredentials.getAccessToken(), deserializedCredentials.getExpiresIn()), USER, deserializedCredentials.getExpiresAt())
```