### PR TITLE
Added scope and resource parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,11 @@
             <artifactId>httpclient</artifactId>
             <version>4.5</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.7</version>
+        </dependency>
 
 
         <!-- TEST DEPENDENCIES -->


### PR DESCRIPTION
Added the possibility of injecting `scope` and `resource` parameters to the request for getting the server token.

Before this change, a client could not inject those values in case of need. For example, those parameters are mandatory when using _Privacy Broker_