### PR TITLE
Changed from _java.util.Optional_ to the guava Optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,11 @@
             <artifactId>httpclient</artifactId>
             <version>4.5</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>23.6-android</version>
+        </dependency>
 
 
         <!-- TEST DEPENDENCIES -->

--- a/src/main/java/no/spid/api/client/SpidApiClient.java
+++ b/src/main/java/no/spid/api/client/SpidApiClient.java
@@ -1,7 +1,8 @@
 package no.spid.api.client;
 
+import com.google.common.base.Optional;
+
 import java.util.Map;
-import java.util.Optional;
 
 import org.apache.oltu.oauth2.client.OAuthClient;
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest;
@@ -426,7 +427,7 @@ public class SpidApiClient {
     private Optional<String> getUserId(OAuthJSONAccessTokenResponse response) {
         JSONObject jsonBody = new JSONObject(response.getBody());
         String optString = jsonBody.optString("user_id");
-        return optString.equals("false") || optString.equals("") ? Optional.<String>empty() : Optional.of(jsonBody.getString("user_id"));
+        return optString.equals("false") || optString.equals("") ? Optional.<String>absent() : Optional.of(jsonBody.getString("user_id"));
     }
 
     /**

--- a/src/main/java/no/spid/api/oauth/SpidOAuthToken.java
+++ b/src/main/java/no/spid/api/oauth/SpidOAuthToken.java
@@ -1,6 +1,7 @@
 package no.spid.api.oauth;
 
-import java.util.Optional;
+
+import com.google.common.base.Optional;
 
 import org.apache.oltu.oauth2.common.token.OAuthToken;
 
@@ -14,7 +15,7 @@ public class SpidOAuthToken {
     private Long expiresIn;
     private Long expiresAt;
     private SpidOAuthTokenType type;
-    private Optional<String> userId = Optional.empty();
+    private Optional<String> userId = Optional.absent();
 
     public SpidOAuthToken(OAuthToken basicToken, SpidOAuthTokenType type, Optional<String> userId) {
         this(basicToken, type, System.currentTimeMillis() + basicToken.getExpiresIn() * 1000);

--- a/src/test/java/no/spid/api/client/SpidApiClientTest.java
+++ b/src/test/java/no/spid/api/client/SpidApiClientTest.java
@@ -1,5 +1,7 @@
 package no.spid.api.client;
 
+import com.google.common.base.Optional;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -15,7 +17,6 @@ import static org.mockito.Mockito.when;
 
 import java.net.URL;
 import java.util.Arrays;
-import java.util.Optional;
 
 import org.apache.oltu.oauth2.client.HttpClient;
 import org.apache.oltu.oauth2.client.request.OAuthClientRequest;
@@ -245,7 +246,7 @@ public class SpidApiClientTest {
         assertEquals(SUCCESSFUL_ACCESS_TOKEN, token.getAccessToken());
         assertEquals(SUCCESSFUL_REFRESH_TOKEN, token.getRefreshToken());
         assertEquals(Long.valueOf(2419200), token.getExpiresIn());
-        assertEquals(token.getUserId(), Optional.empty());
+        assertEquals(token.getUserId(), Optional.absent());
     }
 
     /** END OF TESTS **/


### PR DESCRIPTION
Since the addition of the `java.util.Optional` usage here, this library does not work anymore with versions of java older than 8.
I have changed that _Optional_ for the guava one, so that this library is again compliant with java versions older than _java8_.